### PR TITLE
support for multiple sections

### DIFF
--- a/src/main/clojure/clostache/parser.clj
+++ b/src/main/clojure/clostache/parser.clj
@@ -66,7 +66,7 @@
       (let [before (.substring template 0 (:start section))
             after (.substring template (:end section))
             section-data ((keyword (:name section)) data)]
-        (str (replace-all before replacements)
+        (recur (str before
              (if (:inverted section)
                (if (or (and (vector? section-data) (empty? section-data))
                        (not section-data))
@@ -75,4 +75,4 @@
                  (map-str (fn [m] (render (:body section) m)) section-data)
                  (if section-data
                    (replace-all (:body section) replacements))))
-             (replace-all after replacements))))))
+             after) data)))))

--- a/src/test/clojure/clostache/test_parser.clj
+++ b/src/test/clojure/clostache/test_parser.clj
@@ -25,6 +25,11 @@
                                         {:names [{:name "Felix"}
                                                  {:name "Jenny"}]}))))
 
+(deftest test-render-list-twice
+  (is (= "Hello, Felix, Jenny! Hello, Felix, Jenny!" (render "Hello{{#names}}, {{name}}{{/names}}! Hello{{#names}}, {{name}}{{/names}}!"
+                                        {:names [{:name "Felix"}
+                                                 {:name "Jenny"}]}))))
+
 (deftest test-render-empty-list
   (is (= "" (render "{{#things}}Something{{/things}}" {:things []}))))
 


### PR DESCRIPTION
Hi,

I discovered, that clostache don't support multiple sections, for example:

--cut--

<ul>
{{#sections}}
  <li>{{title}}</li>
{{/sections}}
</ul>

{{#sections}}
  <div>{{content}}</div>
{{/sections}}
--cut--

i don't know if it is supposed to, but it seems reasonable.

I added a test, and made clostache.parser.render to recursively call itself. I don't know if this is efficient, but it seems to work, and all tests passed.
