### PR TITLE
Escape replaceAll argument to fix using dollar signs in template values

### DIFF
--- a/src/main/clojure/clostache/parser.clj
+++ b/src/main/clojure/clostache/parser.clj
@@ -1,6 +1,8 @@
 (ns clostache.parser
   "A parser for mustache templates."
-  (:use [clojure.contrib.string :only (map-str)]))
+  (:use [clojure.contrib.string :only (map-str)])
+  (:import java.util.regex.Matcher)
+  )
 
 (defrecord Section [name body start end inverted])
 
@@ -8,7 +10,7 @@
   "Applies all replacements from the replacement list to the string."
   [string replacements]
   (reduce (fn [string [from to]]
-            (.replaceAll string from to)) string replacements))
+            (.replaceAll string from (Matcher/quoteReplacement to))) string replacements))
 
 (defn- escape-html
   "Replaces angle brackets with the respective HTML entities."

--- a/src/test/clojure/clostache/test_parser.clj
+++ b/src/test/clojure/clostache/test_parser.clj
@@ -5,11 +5,15 @@
 (deftest test-render-simple
   (is (= "Hello, Felix" (render "Hello, {{name}}" {:name "Felix"}))))
 
+(deftest test-render-with-dollar-sign
+  (is (= "Hello, $Felix!" (render "Hello, {{! This is a comment.}}{{name}}!"
+                                 {:name "$Felix"}))))
+
 (deftest test-render-multi-line
   (is (= "Hello\nFelix" (render "Hello\n{{name}}" {:name "Felix"}))))
 
 (deftest test-render-html-unescaped
-  (is (= "&\"<>"
+  (is (= "&\\\"<>"
          (render "{{{string}}}" {:string "&\\\"<>"}))))
 
 (deftest test-render-html-unescaped-ampersand
@@ -78,3 +82,4 @@
 (deftest test-render-inverted-boolean-false
   (is (= "Hello, Felix" (render "Hello, {{^condition}}Felix{{/condition}}"
                                 {:condition false}))))
+


### PR DESCRIPTION
Fixed issue with quoting dollar signs and the regular expression syntax used by .replaceAll in the replace-all function, and added a unit test for it. Also, I think I fixed an omitted \ in the test-render-html-unescaped test, but I am not sure.

Basically, this call now works:

```
(clostache.parser/render "{{value}} store" {:value "$1"})
```
