### PR TITLE
Migrate to Clojure 1.3.0, drop monolithic contrib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,7 @@
         <dependency>
             <groupId>org.clojure</groupId>
             <artifactId>clojure</artifactId>
-            <version>1.2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.clojure</groupId>
-            <artifactId>clojure-contrib</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>jline</groupId>

--- a/src/main/clojure/clostache/parser.clj
+++ b/src/main/clojure/clostache/parser.clj
@@ -1,7 +1,14 @@
 (ns clostache.parser
   "A parser for mustache templates."
-  (:use [clojure.contrib.string :only (map-str split)])
+  (:use [clojure.string :only (split)])
   (:import java.util.regex.Matcher))
+
+(defn- ^String map-str
+  "Apply f to each element of coll, concatenate all results into a
+  String."
+  [f coll]
+  (apply str (map f coll)))
+
 
 (defrecord Section [name body start end inverted])
 
@@ -269,7 +276,7 @@
         section-end-tag (= tag-type \/)
         builder (StringBuilder.)
         tail-builder (if section-tag nil (StringBuilder.))
-        elements (split #"\." tag)
+        elements (split tag #"\.")
         element-to-invert (if (= tag-type \^)
                             (loop [path [(first elements)]
                                    remaining-elements (rest elements)]


### PR DESCRIPTION
From what I see, most of the OSS Clojure ecosystem now targets 1.3.0+. I suggest that Clostache does the same for its 1.2.0 release.

I would be happy to help with migrating Clostache to Leiningen 1 (or 2 preview, which allows testing against Clojure 1.3 and 1.4 betas without any plugins), too.
