### PR TITLE
Clojure 1.4.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
   :source-paths ["src/main/clojure"]
   :test-paths ["src/test/clojure"]
   :resource-paths ["src/test/resources"]
-  :profiles {:1.4 {:dependencies [[org.clojure/clojure "1.4.0-beta6"]]}}
+  :profiles {:1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}}
+  :repositories {"clojure-releases" "http://build.clojure.org/releases"}
   :aliases {"all" ["with-profile" "dev:dev,1.4"]}
   :warn-on-reflection true)


### PR DESCRIPTION
Maven Central does not have 1.4.0 and won't have it for a few days, so lets
just add Clojure releases Maven repo and be done with it.
