### PR TITLE
Fix rendering of nested partials. Tests added.

### DIFF
--- a/src/main/clojure/clostache/parser.clj
+++ b/src/main/clojure/clostache/parser.clj
@@ -228,10 +228,12 @@
 (defn replace-variables
   "Replaces variables in the template with their values from the data."
   [template data partials]
-  (let [regex #"\{\{(\{|\&|)\s*(.*?)\s*\}{2,3}"]
+  (let [regex #"\{\{(\{|\&|\>|)\s*(.*?)\s*\}{2,3}"]
     (replace-all-callback template regex
                           #(let [var-name (nth % 2)
-                                 var-value ((keyword var-name) data)
+                                 var-k (keyword var-name)
+                                 var-type (second %)
+                                 var-value (var-k data)
                                  var-value (if (fn? var-value)
                                              (render-template
                                               (var-value)
@@ -240,9 +242,9 @@
                                              var-value)
                                  var-value (Matcher/quoteReplacement
                                             (str var-value))]
-                             (if (= (second %) "")
-                               (escape-html var-value)
-                               var-value)))))
+                             (cond (= var-type "") (escape-html var-value)
+                                   (= var-type ">") (render-template (var-k partials) data partials)
+                                   :else var-value)))))
 
 (defn- join-standalone-delimiter-tags
   "Remove newlines after standalone (i.e. on their own line) delimiter tags."

--- a/src/test/clojure/clostache/test_parser.clj
+++ b/src/test/clojure/clostache/test_parser.clj
@@ -117,3 +117,14 @@
 
 (deftest test-render-resource-template
   (is (= "Hello, Felix" (render-resource "templates/hello.mustache" {:name "Felix"}))))
+
+(deftest test-render-with-partial
+  (is (= "Hi, Felix" (render "Hi, {{>name}}" {:n "Felix"} {:name "{{n}}"}))))
+
+(deftest test-render-partial-recursive
+  (is (= "One Two Three Four Five" (render "One {{>two}}"
+                                            {}
+                                            {:two "Two {{>three}}"
+                                             :three "Three {{>four}}"
+                                             :four "Four {{>five}}"
+                                             :five "Five"}))))


### PR DESCRIPTION
Even though it isn't in the spec, both `js` and `php` versions of mustache have this behavior.

``` clj
(use 'clostache.parser)

(let [template "One {{>two}}"  
      d {}
      partials {:two "Two {{>three}}"
                :three "Three {{>four}}"
                :four "Four {{>five}}"
                :five "Five"}]  
  ;; old behavior
  (render template d partials) ;;=> "One Two"

  ;; new behavior
  (render template d partials)) ;;=> "One Two Three Four Five"
```
