### PR TITLE
Moved development dependencies to the dev profile

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,13 +5,13 @@
   :license {:name "GNU Lesser General Public License 2.1"
             :url "http://www.gnu.org/licenses/lgpl-2.1.txt"
             :distribution :repo}
-  :dependencies [[org.clojure/clojure "1.3.0"]
-                 [jline/jline "0.9.94"]
-                 [org.clojure/data.json "0.1.2"]]
+  :dependencies [[org.clojure/clojure "1.3.0"]]
   :source-paths ["src/main/clojure"]
   :test-paths ["src/test/clojure"]
-  :resource-paths ["src/test/resources"]
-  :profiles {:1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}}
+  :profiles {:dev {:dependencies [[org.clojure/data.json "0.1.2"]
+                                  [jline/jline "0.9.94"]]
+                   :resource-paths ["src/test/resources"]}
+             :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}}
   :repositories {"clojure-releases" "http://build.clojure.org/releases"}
   :aliases {"all" ["with-profile" "dev:dev,1.4"]}
   :warn-on-reflection true)


### PR DESCRIPTION
So that data.json and jline aren't unnecessarily pulled into projects using clostache.
