### PR TITLE
provide empty data map to render and render-resource

### DIFF
--- a/src/clostache/parser.clj
+++ b/src/clostache/parser.clj
@@ -383,6 +383,8 @@
 
 (defn render
   "Renders the template with the data and, if supplied, partials."
+  ([template]
+     (render template {} {}))
   ([template data]
      (render template data {}))
   ([template data partials]
@@ -392,6 +394,8 @@
 
 (defn render-resource
   "Renders a resource located on the classpath"
+  ([^String path]
+     (render (slurp (io/resource path)) {}))
   ([^String path data]
      (render (slurp (io/resource path)) data))
   ([^String path data partials]


### PR DESCRIPTION
I'm not sure if this is something you'd want to allow or not. I've used some other mustache template libs, in other languages, that allowed this. Anyway, I'm also new to Clojure so this may or may not be the best way to go about this. This was just a possible way to do it that I saw.

This adds another overloaded `render` and `render-resource` that simply provide an empty map if they're only passed in a single parameter.

This is useful because it still allows you to take advantage of various features of this lib, even if you don't explicitly need a data map.
