### PR TITLE
Allow variable containing template

### DIFF
--- a/test/clostache/test_parser.clj
+++ b/test/clostache/test_parser.clj
@@ -128,3 +128,7 @@
                                              :three "Three {{>four}}"
                                              :four "Four {{>five}}"
                                              :five "Five"}))))
+
+(deftest test-render-with-variable-containing-template
+  (is (= "{{hello}},world" (render "{{tmpl}},{{hello}}" {:tmpl "{{hello}}" :hello "world"}))))
+


### PR DESCRIPTION
Clostache cannot render following template correctly.

mustache:

``` ruby
puts Mustache.render("{{a}}-{{b}}", {:a => "{{b}}", :b => "c"})
# => "{{b}}-c"
```

clostache:

``` clojure
(println (render "{{a}}-{{b}}" {:a "{{b}}" :b "c"}))
; => "c-"
```
