### PR TITLE
Add failing test for dotted access inside section (should this work?)

### DIFF
--- a/test/clostache/test_parser.clj
+++ b/test/clostache/test_parser.clj
@@ -107,6 +107,10 @@
   (is (= "Hello, Felix" (render "Hello, {{felix.name}}"
                                 {:felix {:name "Felix"}}))))
 
+(deftest test-render-tag-with-dotted-name-like-section--inside-another-section
+  (is (= "photo thumb" (render "{{#photos}}{{src}} {{thumb.src}}{{/photos}}"
+                                {:photos [{:src "photo" :thumb {:src "thumb"}}]}))))
+
 (deftest test-render-lambda
   (is (= "Hello, Felix" (render "Hello, {{name}}"
                                 {:name (fn [] "Felix")}))))


### PR DESCRIPTION
Fails (prints nothing):
{{#photos}} {{thumb.src}} {{/photos}}

Works (prints photo's thumb's src):
{{#photos}} {{#thumb}}{{src}}{{/thumb}} {{/photos}}

First example should work same as second one, but it fails.
