### PR TITLE
Handle path whitespace consistently

### DIFF
--- a/src/clostache/parser.clj
+++ b/src/clostache/parser.clj
@@ -298,7 +298,7 @@
       (if-let [match (re-find matcher)]
         (let [match-start (.start matcher)
               match-end (.end matcher)
-              converted (convert-path (nth match 2) (nth match 1)
+              converted (convert-path (str/trim (nth match 2)) (nth match 1)
                                       (nth match 3) data)]
           (recur (str (.substring s 0 match-start) converted
                       (.substring s match-end))))

--- a/test/clostache/test_parser.clj
+++ b/test/clostache/test_parser.clj
@@ -142,3 +142,9 @@
     (is (= "135" (render "{{#l}}{{x}}{{/l}}" {:l l})))
     (is (= "" (render "{{^l}}X{{/l}}" {:l l}))))
   (is (= "X" (render "{{^l}}X{{/l}}" {:l (sorted-set)}))))
+
+(deftest test-path-whitespace-handled-consistently
+  (is (= (render "{{a}}" {:a "value"}) "value"))
+  (is (= (render "{{ a }}" {:a "value"}) "value"))
+  (is (= (render "{{a.b}}" {:a {:b "value"}}) "value"))
+  (is (= (render "{{ a.b }}" {:a {:b "value"}}) "value")))


### PR DESCRIPTION
Previously, white space in var lookups was not handled consistently
between flat values and dotted notation. For instance, both `{{var}}`
and `{{ var }}` are handled consistently. When using dotted notation,
`{{map.var}}` works as expected, but `{{ map.var }}` would break. This
was due to the leading whitespace being passed along with the path,
resulting in the `: map` keyword, which didn't exist.

The solution presented resolves this by trimming whitespace from all
path components.
