### PR TITLE
Don't pull irrelevant keys out of the data.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,8 @@
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.clojure/core.incubator "0.1.2"]]
   :profiles {:dev {:dependencies [[org.clojure/data.json "0.1.2"]
-                                  [jline/jline "0.9.94"]]
+                                  [jline/jline "0.9.94"]
+                                  [strictly "0.1.0-SNAPSHOT"]]
                    :resource-paths ["test-resources"]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}}
   :repositories {"clojure-releases" "http://build.clojure.org/releases"}

--- a/test/clostache/test_parser.clj
+++ b/test/clostache/test_parser.clj
@@ -1,6 +1,7 @@
 (ns clostache.test-parser
   (:use clojure.test
-        clostache.parser))
+        clostache.parser
+        strictly.map))
 
 (deftest test-render-simple
   (is (= "Hello, Felix" (render "Hello, {{name}}" {:name "Felix"}))))
@@ -106,6 +107,10 @@
 (deftest test-render-tag-with-dotted-name-like-section
   (is (= "Hello, Felix" (render "Hello, {{felix.name}}"
                                 {:felix {:name "Felix"}}))))
+
+(deftest test-doesnt-retrieve-irrelevant-keys
+  (is (= "FelixFelix" (render "{{felix.name.first}}{{felix.name.first}}"
+                              (strict {:felix {:name {:first "Felix"}}})))))
 
 (deftest test-render-lambda
   (is (= "Hello, Felix" (render "Hello, {{name}}"


### PR DESCRIPTION
I don't have a fix for this yet, but here's a test showing that `process-set-delimiters` is doing something funny. When I use strictly to enforce that bogus keys aren't being retrieved from the map, I see that sometimes the second part of a dotted form is searched for at the top of the map.

This causes me problems because I'd like to use strictly to ensure that I don't inadvertently make inconsistencies between my templates and my data (which allow me to effectively override the silent treatment of nils).

I also wonder if this problem isn't causing other observable effects - though I don't know of any personally.
