### PR TITLE
Fix to enable using dotted access notation in a section

### DIFF
--- a/test/clostache/test_parser.clj
+++ b/test/clostache/test_parser.clj
@@ -107,6 +107,23 @@
   (is (= "Hello, Felix" (render "Hello, {{felix.name}}"
                                 {:felix {:name "Felix"}}))))
 
+(deftest test-render-tag-with-dotted-name-like-section-inside-another-section
+  (is (= "Hello, Felix" (render "Hello, {{#person}}{{felix.name}}{{/person}}"
+                                {:person {:felix {:name "Felix"}}}))))
+
+(deftest test-render-tag-with-multiple-dotted-name-like-section-inside-another-section
+  (is (= "Hello, Felix FELIX" (render "Hello, {{#person}}{{felix.name}} {{felix.upper}}{{/person}}"
+                                      {:person {:felix {:name "Felix" :upper "FELIX"}}}))))
+
+(deftest test-render-tag-with-multiple-dotted-name-like-section-inside-different-sections
+  (is (= "Hello, Felix FELIX 21 Some Address" (render "Hello, {{#person}}{{felix.name}} {{felix.upper}}{{/person}} {{#address}}{{home.line1}}{{/address}}"
+                                                      {:person {:felix {:name "Felix" :upper "FELIX"} }
+                                                       :address {:home {:line1 "21 Some Address"}}}))))
+
+(deftest test-render-tag-with-dotted-name-like-section-inside-multiple-sections
+  (is (= "Hello, Felix" (render "Hello, {{#person}}{{#felix}}{{name.first}}{{/felix}}{{/person}}"
+                                {:person {:felix {:name {:first "Felix"}}}}))))
+
 (deftest test-render-lambda
   (is (= "Hello, Felix" (render "Hello, {{name}}"
                                 {:name (fn [] "Felix")}))))


### PR DESCRIPTION
Hi, 

First, thanks for making clostache, I've used it in a few different projects so I appreciate the effort you've put in. 

This pull requests is to create tests and an implementation for dotted access inside a section. Like so:

```
"Hello, {{#person}}{{#felix}}{{name.first}}{{/felix}}{{/person}}"
```

or

```
"Hello, {{#person}}{{#felix}}{{name.first}} {{name.last}}{{/felix}}{{/person}}"
```

Its worth saying that I'm pretty new to Clojure, so I don't doubt that there is a better implementation available. This does work though and all of the tests pass. I'm happy if the implementation needs to change, I just needed to get it fixed.

I'd be interested to know your thoughts and eager to understand any improvements you can think of or any problems I might have unknowingly caused. 

As a brief summary, what I've done is enabled the `data` passed into `convert-path` to be valid for the given dot notation. I've done this by doing a `(get-in data in-sections)`. I've derived `in-sections` based on the positioning of the dot notation within (nested)section nodes.

I'd be interested to know if there is a better, more concise way to do this with a single regex matcher.

Cheers!
