### PR TITLE
Now HTML escapes single quotes

### DIFF
--- a/src/clostache/parser.clj
+++ b/src/clostache/parser.clj
@@ -35,7 +35,8 @@
   (replace-all string [["&" "&amp;"]
                        ["\"" "&quot;"]
                        ["<" "&lt;"]
-                       [">" "&gt;"]]))
+                       [">" "&gt;"]
+                       ["'","&apos;"]]))
 
 (defn- indent-partial
   "Indent all lines of the partial by indent."

--- a/test/clostache/test_parser.clj
+++ b/test/clostache/test_parser.clj
@@ -27,8 +27,8 @@
          (render "{{&string}}" {:string "&\"<>"}))))
 
 (deftest test-render-html-escaped
-  (is (= "&amp;&quot;&lt;&gt;"
-         (render "{{string}}" {:string "&\"<>"}))))
+  (is (= "&amp;&quot;&lt;&gt;&apos;"
+         (render "{{string}}" {:string "&\"<>'"}))))
 
 (deftest test-render-list
   (is (= "Hello, Felix, Jenny!" (render "Hello{{#names}}, {{name}}{{/names}}!"


### PR DESCRIPTION
Using a moustache inside a HTML attribute wrapped with single quotes will allow a user to execute malicious JavaScript because Clostache doesn't escape single quotes.

Example: `<a href='/user/{{username}}'>{{username}}</a>` can be easily escaped if `username` was set to `foo' onmouseover='alert(1)`.

We should also be escaping more characters due to the crazy nature in which people can write renderable HTML, but single quoted attributes is a pretty common thing.

Reference: http://wonko.com/post/html-escaping