### PR TITLE
add *escape-strategy*

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,16 +1,8 @@
-(defproject de.ubercode.clostache/clostache "1.5.0-SNAPSHOT"
+(defproject edw/clj-mustache "1.0.0-SNAPSHOT"
   :min-lein-version "2.0.0"
-  :description "{{ mustache }} for Clojure"
-  :url "http://github.com/fhd/clostache"
+  :description "Mustache templating for Clojure"
+  :url "http://github.com/edw/clj-mustache"
   :license {:name "GNU Lesser General Public License 2.1"
             :url "http://www.gnu.org/licenses/lgpl-2.1.txt"
             :distribution :repo}
-  :dependencies [[org.clojure/clojure "1.3.0"]
-                 [org.clojure/core.incubator "0.1.2"]]
-  :profiles {:dev {:dependencies [[org.clojure/data.json "0.1.2"]
-                                  [jline/jline "0.9.94"]]
-                   :resource-paths ["test-resources"]}
-             :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}}
-  :repositories {"clojure-releases" "http://build.clojure.org/releases"}
-  :aliases {"all" ["with-profile" "dev:dev,1.4"]}
-  :warn-on-reflection true)
+  :dependencies [[org.clojure/clojure "1.7.0"]])

--- a/src/clostache/parser.clj
+++ b/src/clostache/parser.clj
@@ -1,9 +1,7 @@
 (ns clostache.parser
   "A parser for mustache templates."
-  (:use [clojure.string :only (split)]
-        [clojure.core.incubator :only (seqable?)])
   (:require [clojure.java.io :as io]
-            [clojure.string  :as str])
+            [clojure.string :as str :refer [split]])
   (:import java.util.regex.Matcher))
 
 (defn- ^String map-str
@@ -349,11 +347,13 @@
         template (convert-paths template data)]
     [template data]))
 
+(defn- iterable? [x] (instance? Iterable x))
+
 (defn- render-section
   [section data partials]
   (let [section-data ((keyword (:name section)) data)]
     (if (:inverted section)
-      (if (or (and (seqable? section-data) (empty? section-data))
+      (if (or (and (iterable? section-data) (empty? section-data))
               (not section-data))
         (:body section))
       (if section-data
@@ -364,7 +364,7 @@
               result))
           (let [section-data (cond (sequential? section-data) section-data
                                    (map? section-data) [section-data]
-                                   (seqable? section-data) (seq section-data)
+                                   (iterable? section-data) (seq section-data)
                                    :else [{}])
                 section-data (if (map? (first section-data))
                                section-data

--- a/src/clostache/parser.clj
+++ b/src/clostache/parser.clj
@@ -238,7 +238,7 @@
 (defn replace-variables
   "Replaces variables in the template with their values from the data."
   [template data partials]
-  (let [regex #"\{\{(\{|\&|\>|)\s*(.*?)\s*\}{2,3}"]
+  (let [regex #"\{\{([{&>%;]{0,1})\s*(.*?)\s*\}{2,3}"]
     (replace-all-callback template regex
                           #(let [var-name (nth % 2)
                                  var-k (keyword var-name)
@@ -253,6 +253,8 @@
                                  var-value (Matcher/quoteReplacement
                                             (str var-value))]
                              (cond (= var-type "") (escape-content var-value)
+                                   (= var-type "%") (escape-url var-value)
+                                   (= var-type ";") (escape-html var-value)
                                    (= var-type ">") (render-template (var-k partials) data partials)
                                    :else var-value)))))
 

--- a/src/clostache/parser.clj
+++ b/src/clostache/parser.clj
@@ -252,11 +252,12 @@
                                              var-value)
                                  var-value (Matcher/quoteReplacement
                                             (str var-value))]
-                             (cond (= var-type "") (escape-content var-value)
-                                   (= var-type "%") (escape-url var-value)
-                                   (= var-type ";") (escape-html var-value)
-                                   (= var-type ">") (render-template (var-k partials) data partials)
-                                   :else var-value)))))
+                             (case var-type
+                               "" (escape-content var-value)
+                               "%" (escape-url var-value)
+                               ";" (escape-html var-value)
+                               ">" (render-template (var-k partials) data partials)
+                               var-value)))))
 
 (defn- join-standalone-delimiter-tags
   "Remove newlines after standalone (i.e. on their own line) delimiter tags."

--- a/src/clostache/parser.clj
+++ b/src/clostache/parser.clj
@@ -37,6 +37,29 @@
                        ["<" "&lt;"]
                        [">" "&gt;"]]))
 
+(defn- escape-url
+  "Replaces syntactically-significant URL characters with encoded
+   counterparts."
+  [string]
+  (java.net.URLEncoder/encode string))
+
+(def ^:private escape-strategies
+  {:html escape-html
+   :url escape-url})
+
+(def ^:dynamic *escape-strategy*
+  "When `:html` (the default), rendering escapes characters sensitive
+   to HTML. When `:url`, rendering URL-encodes appropriate characters."
+  :html)
+
+(defn- escape-content
+  "Replaces sensitive characters with their respective escaped
+   versions, using an escaping scheme determined by the value of
+   `*escape-strategy*`."
+  [string]
+  ((*escape-strategy* escape-strategies) string))
+
+
 (defn- indent-partial
   "Indent all lines of the partial by indent."
   [partial indent]
@@ -229,7 +252,7 @@
                                              var-value)
                                  var-value (Matcher/quoteReplacement
                                             (str var-value))]
-                             (cond (= var-type "") (escape-html var-value)
+                             (cond (= var-type "") (escape-content var-value)
                                    (= var-type ">") (render-template (var-k partials) data partials)
                                    :else var-value)))))
 

--- a/src/mustache/parser.clj
+++ b/src/mustache/parser.clj
@@ -1,4 +1,4 @@
-(ns clostache.parser
+(ns mustache.parser
   "A parser for mustache templates."
   (:require [clojure.java.io :as io]
             [clojure.string :as str :refer [split]])

--- a/src/mustache/parser.clj
+++ b/src/mustache/parser.clj
@@ -50,6 +50,13 @@
    to HTML. When `:url`, rendering URL-encodes appropriate characters."
   :html)
 
+(defmacro with-url-escaping
+  "Within the dynamic lifetime of this form, render templates with URL
+   escaping."
+  [& body]
+  `(binding [*escape-strategy* :url]
+     ~@body))
+
 (defn- escape-content
   "Replaces sensitive characters with their respective escaped
    versions, using an escaping scheme determined by the value of


### PR DESCRIPTION
We use templating extensively but it is in the context of creating URLs and therefore HTML escaping doesn't work well for us. This pull request creates a dynamic var, `*escape-strategy*`, which can be bound to either `:html` (the default) or `:url`, and escaping will proceed according to the value.

I can imagine creating some syntax to switch the strategy, as even in HTML sometimes one wants to construct URLs, and having the ability to switch from HTML to URL encoding would be handy. I've therefore added two new pieces of syntax to explicitly choose HTML (`{{; name }}`) or URL (`{{% name }}`) encoding.

Here's an example of the dynamic var in use:

```clojure
(let [template "Hello, {{people}}!"
      data {:people "Felix & Oscar"}]
  (binding [*escape-strategy* :url]
    (println (render template data)))
  (println (render template data)))
```

The output:
```
Hello, Felix+%26+Oscar!
Hello, Felix &amp; Oscar!
```