### PR TITLE
Add support for clojure 1.9

### DIFF
--- a/src/clostache/parser.clj
+++ b/src/clostache/parser.clj
@@ -1,7 +1,7 @@
 (ns clostache.parser
   "A parser for mustache templates."
   (:use [clojure.string :only (split)]
-        [clojure.core.incubator :only (seqable?)])
+        [clojure.core :only (seqable?)])
   (:refer-clojure :exclude (seqable?))
   (:require [clojure.java.io :as io]
             [clojure.string  :as str])


### PR DESCRIPTION
I have removed the .incubator so that clostache can be used with clojure 1.9 