### PR TITLE
[FIX] string are seqable, but (maybe) you want to render it instead o…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: clojure
-lein: lein2
-script: lein2 all test
+lein: lein
+script: lein all test
 before_install:
   - git submodule update --init --recursive
 jdk:
-  - openjdk6
   - openjdk7
+  - openjdk8
   - oraclejdk7
+  - oraclejdk8

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject de.ubercode.clostache/clostache "1.5.0-SNAPSHOT"
+(defproject de.ubercode.clostache/clostache "1.5.0"
   :min-lein-version "2.0.0"
   :description "{{ mustache }} for Clojure"
   :url "http://github.com/fhd/clostache"

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,7 @@
   :license {:name "GNU Lesser General Public License 2.1"
             :url "http://www.gnu.org/licenses/lgpl-2.1.txt"
             :distribution :repo}
-  :dependencies [[org.clojure/clojure "1.5.0"]
-                 [org.clojure/core.incubator "0.1.2"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]]
   :profiles {:dev {:dependencies [[org.clojure/data.json "0.1.2"]
                                   [jline/jline "0.9.94"]]
                    :resource-paths ["test-resources"]}

--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
   :profiles {:dev {:dependencies [[org.clojure/data.json "0.1.2"]
                                   [jline/jline "0.9.94"]]
                    :resource-paths ["test-resources"]}
-             :1.5 {:dependencies [[org.clojure/clojure "1.5.0"]]}}
+             :1.5 {:dependencies [[org.clojure/clojure "1.9.0"]]}}
   :repositories {"clojure-releases" "http://build.clojure.org/releases"}
   :aliases {"all" ["with-profile" "dev:dev,1.5"]}
   :global-vars {*warn-on-reflection* true})

--- a/src/clostache/parser.clj
+++ b/src/clostache/parser.clj
@@ -1,7 +1,6 @@
 (ns clostache.parser
   "A parser for mustache templates."
   (:use [clojure.string :only (split)])
-  (:refer-clojure :exclude (seqable?))
   (:require [clojure.java.io :as io]
             [clojure.string  :as str])
   (:import java.util.regex.Matcher))

--- a/src/clostache/parser.clj
+++ b/src/clostache/parser.clj
@@ -339,7 +339,9 @@
               result))
           (let [section-data (cond (sequential? section-data) section-data
                                    (map? section-data) [section-data]
-                                   (seqable? section-data) (seq section-data)
+                                   (and
+                                      (seqable? section-data)
+                                      (not (string? section-data))) (seq section-data)
                                    :else [{}])
                 section-data (if (map? (first section-data))
                                section-data

--- a/src/clostache/parser.clj
+++ b/src/clostache/parser.clj
@@ -1,7 +1,6 @@
 (ns clostache.parser
   "A parser for mustache templates."
-  (:use [clojure.string :only (split)]
-        [clojure.core.incubator :only (seqable?)])
+  (:use [clojure.string :only (split)])
   (:refer-clojure :exclude (seqable?))
   (:require [clojure.java.io :as io]
             [clojure.string  :as str])
@@ -334,7 +333,7 @@
       (if section-data
         (if (fn? section-data)
           (let [result (section-data (:body section))]
-            (if (fn? result) 
+            (if (fn? result)
               (result #(render-template % data partials))
               result))
           (let [section-data (cond (sequential? section-data) section-data


### PR DESCRIPTION
…f iterate over it

In my template, I don't wan't to iterate over string. 
example
{{#greet}}Hello, World!{{/greet}}

with
{:greet "true"} ;;(not booelan true, but string) 

will return
Hello, World!Hello, World!Hello, World!Hello, World!

This is for me a bit weird.